### PR TITLE
GitHub Actions auto-build

### DIFF
--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -64,7 +64,8 @@ jobs:
           $COMMON_FLAGS
           > setup.sh
       - name: SDL workaround
-        run: "sed -i'' '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
+        run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
+        if: ${{ build_os == 'ubuntu-latest' }}
       - name: Generate Makefile
         run: "bash ./setup.sh"
       - name: Add . to PATH
@@ -73,8 +74,11 @@ jobs:
         run: make
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.3
+        env:
+          SUFFIX: ${{ matrix.host_platform == 'wx64' && '.exe' || '' }}
         with:
           # Artifact name
-          name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}
+          name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}$SUFFIX
           # A file, directory or wildcard pattern that describes what to upload
-          path: minivmac
+          path: minivmac$SUFFIX
+          if-no-files-found: error

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -36,15 +36,18 @@ jobs:
         run: gcc -o setup_t setup/tool.c
       - name: Extra arguemnts (Windows)
         if: host_platform=wx64
-        env:
-          EXTRA_ARGS: "-e mgw"
+        run: echo EXTRA_ARGS="-e mgw" >> $GITHUB_ENV
       - name: Extra arguemnts (macOS)
         if: startsWith(host_platform, 'mc')
-        env:
-          EXTRA_ARGS: "-ev 13000"
+        run: echo EXTRA_ARGS="-ev 13000" >> $GITHUB_ENV
       - name: Build dependancies (Windows)
         if: host_platform=wx64
-        run: apt install -y mingw-w64
+        run: |
+          apt install -y mingw-w64
+          ln -s /usr/bin/x86_64-w64-mingw32-gcc gcc.exe
+          ln -s /usr/bin/x86_64-w64-mingw32-windres windres.exe
+          ln -s /usr/bin/x86_64-w64-mingw32-strip strip.exe
+          ln -s src SRC
       - name: Generate configuration script
         run: >
           ./setup_t -maintainer "${{ github.actor }}"

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -1,0 +1,58 @@
+name: build-packages
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches: [ $default-branch ]
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  create-release:
+    uses: softprops/action-gh-release@v1
+    with:
+      draft: true
+      prerelease: true
+    outputs:
+      create-release: steps.create-release.outputs.assets[0].browser_download_url
+  build-linux:
+    needs: create-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        vmac_type:
+          - II
+          #- Plus
+          #- SE
+        host_platform:
+          - lx64
+    env:
+      COMMON_FLAGS: "-n minivmac-37-bluescsi -bg 1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile setup tool
+        run: gcc -o setup_t setup/tool.c
+      - name: Generate configuration script
+        run: >-
+          ./setup_t -maintainer "$GITHUB_ACTOR"
+            -homepage ${{ repositoryUrl }}
+            -t ${{ matrix.host_platform }}
+            -m ${{ matrix.vmac_type }}
+            $COMMON_FLAGS
+            > setup.sh
+      - name: SDL workaround
+        run: "sed -i '/.*SDL\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \>\> \"\$\{DestFile\}\"' setup.sh"
+      - name: Generate Makefile
+        run: "./setup.sh"
+      - name: Compile
+        run: make
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./minivmac
+          asset_name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}
+          asset_content_type: application/zip

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -33,6 +33,8 @@ jobs:
             host_platform: lx64
           - build_os: macos-latest
             host_platform: wx64
+    strategy:
+      continue-on-error: true
     env:
       COMMON_FLAGS: "-n minivmac-37-bluescsi -bg 1"
     steps:
@@ -63,7 +65,7 @@ jobs:
           $COMMON_FLAGS
           > setup.sh
       - name: SDL workaround
-        run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
+        run: "sed -i "" '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
       - name: Generate Makefile
         run: "bash ./setup.sh"
       - name: Add . to PATH

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -40,12 +40,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Compile setup tool
         run: gcc -o setup_t setup/tool.c
-      - name: Extra arguemnts (Windows)
+      - name: Extra defines (Windows)
         if: ${{ matrix.host_platform=='wx64' }}
-        run: echo EXTRA_ARGS="-e mgw" >> $GITHUB_ENV
-      - name: Extra arguemnts (macOS)
+        run: |
+          echo EXTRA_ARGS="-e mgw" >> $GITHUB_ENV
+          echo SUFFIX=".exe" >> $GITHUB_ENV
+      - name: Extra defines (macOS)
         if: ${{ startsWith(matrix.host_platform, 'mc') }}
-        run: echo EXTRA_ARGS="-ev 13000" >> $GITHUB_ENV
+        run: |
+          echo EXTRA_ARGS="-ev 13000" >> $GITHUB_ENV
+          echo SUFFIX=".app" >> $GITHUB_ENV
       - name: Build dependancies (Windows)
         if: ${{ matrix.host_platform=='wx64' }}
         run: |
@@ -65,20 +69,22 @@ jobs:
           > setup.sh
       - name: SDL workaround
         run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
-        if: ${{ matrix.build_os == 'ubuntu-latest' }}
+        if: ${{ runner.os == 'Linux' }}
       - name: Generate Makefile
         run: "bash ./setup.sh"
       - name: Add . to PATH
         run: echo . >> $GITHUB_PATH
       - name: Compile
+        if: ${{ runner.os == 'Linux' }}
         run: make
+      - name: Compile
+        if: ${{ runner.os == 'macOS' }}
+        run: xcodebuild
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.3
-        env:
-          SUFFIX: ${{ matrix.host_platform == 'wx64' && '.exe' || '' }}
         with:
           # Artifact name
-          name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}$SUFFIX
+          name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}${{ env.SUFFIX }}
           # A file, directory or wildcard pattern that describes what to upload
           path: minivmac$SUFFIX
           if-no-files-found: error

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -41,7 +41,7 @@ jobs:
             $COMMON_FLAGS
             > setup.sh
       - name: SDL workaround
-        run: "sed -i '/.*SDL\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \>\> \"\$\{DestFile\}\"' setup.sh"
+        run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
       - name: Generate Makefile
         run: "./setup.sh"
       - name: Compile

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -11,6 +11,7 @@ jobs:
   build-variant:
     runs-on: ${{ matrix.build_os }}
     strategy:
+      continue-on-error: true
       matrix:
         build_os:
           - ubuntu-latest
@@ -33,8 +34,6 @@ jobs:
             host_platform: lx64
           - build_os: macos-latest
             host_platform: wx64
-    strategy:
-      continue-on-error: true
     env:
       COMMON_FLAGS: "-n minivmac-37-bluescsi -bg 1"
     steps:

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build-linux:
-    needs: create-release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,8 +26,8 @@ jobs:
         run: gcc -o setup_t setup/tool.c
       - name: Generate configuration script
         run: >-
-          ./setup_t -maintainer "$GITHUB_ACTOR"
-            -homepage ${{ repositoryUrl }}
+          ./setup_t -maintainer "${{ github.actor }}"
+            -homepage ${{ github.repositoryUrl }}
             -t ${{ matrix.host_platform }}
             -m ${{ matrix.vmac_type }}
             $COMMON_FLAGS

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -9,27 +9,49 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.build_os }}
     strategy:
       matrix:
+        build_os:
+          ubuntu-latest
         vmac_type:
           - II
           #- Plus
           #- SE
         host_platform:
           - lx64
+          - wx64
+          #- mc64
+          #- mcar
+        include:
+          - host_platform: mc64
+            build_os: macos-latest
+          - host_platform: mcar
+            build_os: macos-latest
     env:
       COMMON_FLAGS: "-n minivmac-37-bluescsi -bg 1"
     steps:
       - uses: actions/checkout@v4
       - name: Compile setup tool
         run: gcc -o setup_t setup/tool.c
+      - name: Extra arguemnts (Windows)
+        if: host_platform=wx64
+        env:
+          EXTRA_ARGS: "-e mgw"
+      - name: Extra arguemnts (macOS)
+        if: startsWith(host_platform, 'mc')
+        env:
+          EXTRA_ARGS: "-ev 13000"
+      - name: Build dependancies (Windows)
+        if: host_platform=wx64
+        run: apt install -y mingw-w64
       - name: Generate configuration script
         run: >
           ./setup_t -maintainer "${{ github.actor }}"
           -homepage ${{ github.repositoryUrl }}
           -t ${{ matrix.host_platform }}
           -m ${{ matrix.vmac_type }}
+          $EXTRA_ARGS
           $COMMON_FLAGS
           > setup.sh
       - name: SDL workaround

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -10,6 +10,7 @@ permissions:
   contents: write
 jobs:
   create-release:
+    runs-on: ubuntu-latest
     steps:
       - uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -21,13 +21,13 @@ jobs:
         host_platform:
           - lx64
           - wx64
-          #- mc64
-          #- mcar
         include:
           - host_platform: mc64
             build_os: macos-latest
+            vmac_type: ${{ matrix.vmac_type }}
           - host_platform: mcar
             build_os: macos-latest
+            vmac_type: ${{ matrix.vmac_type }}
     env:
       COMMON_FLAGS: "-n minivmac-37-bluescsi -bg 1"
     steps:
@@ -43,7 +43,7 @@ jobs:
       - name: Build dependancies (Windows)
         if: ${{ matrix.host_platform=='wx64' }}
         run: |
-          apt install -y mingw-w64
+          sudo apt install -y mingw-w64
           ln -s /usr/bin/x86_64-w64-mingw32-gcc gcc.exe
           ln -s /usr/bin/x86_64-w64-mingw32-windres windres.exe
           ln -s /usr/bin/x86_64-w64-mingw32-strip strip.exe

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -5,6 +5,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
     branches: [ $default-branch ]
   workflow_dispatch:
+  pull_request:
 permissions:
   contents: write
 jobs:
@@ -57,3 +58,10 @@ jobs:
           asset_path: ./minivmac
           asset_name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}
           asset_content_type: application/zip
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          # Artifact name
+          name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}
+          # A file, directory or wildcard pattern that describes what to upload
+          path: minivmac

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -65,7 +65,7 @@ jobs:
           > setup.sh
       - name: SDL workaround
         run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
-        if: ${{ build_os == 'ubuntu-latest' }}
+        if: ${{ matrix.build_os == 'ubuntu-latest' }}
       - name: Generate Makefile
         run: "bash ./setup.sh"
       - name: Add . to PATH

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -9,10 +9,11 @@ permissions:
   contents: write
 jobs:
   create-release:
-    uses: softprops/action-gh-release@v1
-    with:
-      draft: true
-      prerelease: true
+    steps:
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: true
     outputs:
       create-release: steps.create-release.outputs.assets[0].browser_download_url
   build-linux:

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         build_os:
           - ubuntu-latest
+          - macos-latest
         vmac_type:
           - II
           #- Plus
@@ -21,13 +22,17 @@ jobs:
         host_platform:
           - lx64
           - wx64
-        include:
-          - host_platform: mc64
-            build_os: macos-latest
-            vmac_type: ${{ matrix.vmac_type }}
-          - host_platform: mcar
-            build_os: macos-latest
-            vmac_type: ${{ matrix.vmac_type }}
+          - mc64
+          - mcar
+        exclude:
+          - build_os: ubuntu-latest
+            host_platform: mc64
+          - build_os: ubuntu-latest
+            host_platform: mcar
+          - build_os: macos-latest
+            host_platform: lx64
+          - build_os: macos-latest
+            host_platform: wx64
     env:
       COMMON_FLAGS: "-n minivmac-37-bluescsi -bg 1"
     steps:

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -65,7 +65,7 @@ jobs:
           $COMMON_FLAGS
           > setup.sh
       - name: SDL workaround
-        run: "sed -i "" '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
+        run: "sed -i '' '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
       - name: Generate Makefile
         run: "bash ./setup.sh"
       - name: Add . to PATH

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -6,18 +6,8 @@ on:
     branches: [ $default-branch ]
   workflow_dispatch:
   pull_request:
-permissions:
-  contents: write
+
 jobs:
-  create-release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          prerelease: true
-    outputs:
-      create-release: steps.create-release.outputs.assets[0].browser_download_url
   build-linux:
     needs: create-release
     runs-on: ubuntu-latest
@@ -49,16 +39,6 @@ jobs:
         run: "./setup.sh"
       - name: Compile
         run: make
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./minivmac
-          asset_name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}
-          asset_content_type: application/zip
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.3
         with:

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -35,13 +35,13 @@ jobs:
       - name: Compile setup tool
         run: gcc -o setup_t setup/tool.c
       - name: Extra arguemnts (Windows)
-        if: matrix.host_platform=wx64
+        if: ${{ matrix.host_platform==wx64 }}
         run: echo EXTRA_ARGS="-e mgw" >> $GITHUB_ENV
       - name: Extra arguemnts (macOS)
-        if: startsWith(matrix.host_platform, 'mc')
+        if: ${{ startsWith(matrix.host_platform, 'mc') }}
         run: echo EXTRA_ARGS="-ev 13000" >> $GITHUB_ENV
       - name: Build dependancies (Windows)
-        if: matrix.host_platform=wx64
+        if: ${{ matrix.host_platform==wx64 }}
         run: |
           apt install -y mingw-w64
           ln -s /usr/bin/x86_64-w64-mingw32-gcc gcc.exe

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -10,8 +10,8 @@ on:
 jobs:
   build-variant:
     runs-on: ${{ matrix.build_os }}
+    continue-on-error: true
     strategy:
-      continue-on-error: true
       matrix:
         build_os:
           - ubuntu-latest

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -35,13 +35,13 @@ jobs:
       - name: Compile setup tool
         run: gcc -o setup_t setup/tool.c
       - name: Extra arguemnts (Windows)
-        if: ${{ matrix.host_platform==wx64 }}
+        if: ${{ matrix.host_platform=='wx64' }}
         run: echo EXTRA_ARGS="-e mgw" >> $GITHUB_ENV
       - name: Extra arguemnts (macOS)
         if: ${{ startsWith(matrix.host_platform, 'mc') }}
         run: echo EXTRA_ARGS="-ev 13000" >> $GITHUB_ENV
       - name: Build dependancies (Windows)
-        if: ${{ matrix.host_platform==wx64 }}
+        if: ${{ matrix.host_platform=='wx64' }}
         run: |
           apt install -y mingw-w64
           ln -s /usr/bin/x86_64-w64-mingw32-gcc gcc.exe

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -86,5 +86,5 @@ jobs:
           # Artifact name
           name: minivmac-${{ matrix.host_platform }}-${{ matrix.vmac_type }}${{ env.SUFFIX }}
           # A file, directory or wildcard pattern that describes what to upload
-          path: minivmac$SUFFIX
+          path: minivmac${{ env.SUFFIX }}
           if-no-files-found: error

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build-linux:
+  build-variant:
     runs-on: ${{ matrix.build_os }}
     strategy:
       matrix:
@@ -35,13 +35,13 @@ jobs:
       - name: Compile setup tool
         run: gcc -o setup_t setup/tool.c
       - name: Extra arguemnts (Windows)
-        if: host_platform=wx64
+        if: matrix.host_platform=wx64
         run: echo EXTRA_ARGS="-e mgw" >> $GITHUB_ENV
       - name: Extra arguemnts (macOS)
-        if: startsWith(host_platform, 'mc')
+        if: startsWith(matrix.host_platform, 'mc')
         run: echo EXTRA_ARGS="-ev 13000" >> $GITHUB_ENV
       - name: Build dependancies (Windows)
-        if: host_platform=wx64
+        if: matrix.host_platform=wx64
         run: |
           apt install -y mingw-w64
           ln -s /usr/bin/x86_64-w64-mingw32-gcc gcc.exe

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         build_os:
-          ubuntu-latest
+          - ubuntu-latest
         vmac_type:
           - II
           #- Plus

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -35,7 +35,9 @@ jobs:
       - name: SDL workaround
         run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
       - name: Generate Makefile
-        run: "./setup.sh"
+        run: "bash ./setup.sh"
+      - name: Add . to PATH
+        run: echo . >> $GITHUB_PATH
       - name: Compile
         run: make
       - name: Upload a Build Artifact

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -25,13 +25,13 @@ jobs:
       - name: Compile setup tool
         run: gcc -o setup_t setup/tool.c
       - name: Generate configuration script
-        run: >-
+        run: >
           ./setup_t -maintainer "${{ github.actor }}"
-            -homepage ${{ github.repositoryUrl }}
-            -t ${{ matrix.host_platform }}
-            -m ${{ matrix.vmac_type }}
-            $COMMON_FLAGS
-            > setup.sh
+          -homepage ${{ github.repositoryUrl }}
+          -t ${{ matrix.host_platform }}
+          -m ${{ matrix.vmac_type }}
+          $COMMON_FLAGS
+          > setup.sh
       - name: SDL workaround
         run: "sed -i '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
       - name: Generate Makefile

--- a/.github/workflows/buildpackages.yaml
+++ b/.github/workflows/buildpackages.yaml
@@ -64,7 +64,7 @@ jobs:
           $COMMON_FLAGS
           > setup.sh
       - name: SDL workaround
-        run: "sed -i '' '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
+        run: "sed -i'' '/.*SDL\\.h/i printf \"%s\\n\" \"#define SDL_MAIN_HANDLED\" \\>\\> \"\\$\\{DestFile\\}\"' setup.sh"
       - name: Generate Makefile
         run: "bash ./setup.sh"
       - name: Add . to PATH


### PR DESCRIPTION
Your TinkerDifferent post announcing your fork got me thinking about GitHub Actions so I tried it out.
The workflow still needs a little work but I did get it to build Mac-Intel, Mac-Apple, Windows, and Linux versions of the Mac II emulator. Yanking a couple of comments should get it to build all of those targets for the SE & Plus configs too.

If you want to see the joy of iterating on GitHub Actions take a glance at the 26 commits it took to get all of the syntax errors out.