### PR TITLE
Full screen improvements

### DIFF
--- a/setup/SPBLDOPT.i
+++ b/setup/SPBLDOPT.i
@@ -357,6 +357,56 @@ LOCALPROC WrtOptInitFullScreen(void)
 }
 
 
+/* option: Initial Integer Scaling */
+
+LOCALVAR blnr CanIntScaling;
+LOCALVAR blnr WantInitIntScaling;
+LOCALVAR ui3r olv_InitIntScaling;
+
+LOCALPROC ResetInitIntScaling(void)
+{
+	WantInitIntScaling = nanblnr;
+	olv_InitIntScaling = 0;
+}
+
+LOCALFUNC tMyErr TryAsInitIntScalingNot(void)
+{
+	return BooleanTryAsOptionNot("-integer-scaling",
+		&WantInitIntScaling, &olv_InitIntScaling);
+}
+
+LOCALFUNC blnr dfo_InitIntScaling(void)
+{
+	return falseblnr;
+}
+
+LOCALFUNC tMyErr ChooseInitIntScaling(void)
+{
+	tMyErr err;
+
+    CanIntScaling = (gbk_apifam_sd2 == gbo_apifam || gbk_apifam_cco == gbo_apifam);
+
+	err = kMyErr_noErr;
+
+	if (nanblnr == WantInitIntScaling) {
+		WantInitIntScaling = dfo_InitIntScaling();
+	} else {
+        if (!CanIntScaling) {
+            err = ReportParseFailure(
+                "-integer-scaling is only supported on SDL2 and Cocoa builds");
+        }
+    }
+
+	return err;
+}
+
+LOCALPROC WrtOptInitIntScaling(void)
+{
+	WrtOptBooleanOption("-integer-scaling",
+		WantInitIntScaling, dfo_InitIntScaling());
+}
+
+
 /* option: Variable FullScreen */
 
 LOCALVAR blnr WantVarFullScreen;
@@ -3841,6 +3891,7 @@ LOCALPROC SPResetCommandLineParameters(void)
 	ResetVResOption();
 	ResetScrnDpthOption();
 	ResetInitFullScreen();
+	ResetInitIntScaling();
 	ResetVarFullScreen();
 	ResetMagFctrOption();
 	ResetInitMagnify();
@@ -3913,6 +3964,7 @@ LOCALFUNC tMyErr TryAsSPOptionNot(void)
 	if (kMyErrNoMatch == (err = TryAsVResOptionNot()))
 	if (kMyErrNoMatch == (err = TryAsScrnDpthOptionNot()))
 	if (kMyErrNoMatch == (err = TryAsInitFullScreenNot()))
+	if (kMyErrNoMatch == (err = TryAsInitIntScalingNot()))
 	if (kMyErrNoMatch == (err = TryAsVarFullScreenNot()))
 	if (kMyErrNoMatch == (err = TryAsMagFctrOptionNot()))
 	if (kMyErrNoMatch == (err = TryAsInitMagnifyNot()))
@@ -3989,6 +4041,7 @@ LOCALFUNC tMyErr AutoChooseSPSettings(void)
 	if (kMyErr_noErr == (err = ChooseVRes()))
 	if (kMyErr_noErr == (err = ChooseScrnDpth()))
 	if (kMyErr_noErr == (err = ChooseInitFullScreen()))
+	if (kMyErr_noErr == (err = ChooseInitIntScaling()))
 	if (kMyErr_noErr == (err = ChooseVarFullScreen()))
 	if (kMyErr_noErr == (err = ChooseMagFctr()))
 	if (kMyErr_noErr == (err = ChooseInitMagnify()))
@@ -4071,6 +4124,7 @@ LOCALPROC WrtOptSPSettings(void)
 	WrtOptVResOption();
 	WrtOptScrnDpth();
 	WrtOptInitFullScreen();
+	WrtOptInitIntScaling();
 	WrtOptVarFullScreen();
 	WrtOptMagFctrOption();
 	WrtOptInitMagnify();

--- a/setup/SPBLDOPT.i
+++ b/setup/SPBLDOPT.i
@@ -384,18 +384,18 @@ LOCALFUNC tMyErr ChooseInitIntScaling(void)
 {
 	tMyErr err;
 
-    CanIntScaling = (gbk_apifam_sd2 == gbo_apifam || gbk_apifam_cco == gbo_apifam);
+	CanIntScaling = (gbk_apifam_sd2 == gbo_apifam || gbk_apifam_cco == gbo_apifam);
 
 	err = kMyErr_noErr;
 
 	if (nanblnr == WantInitIntScaling) {
 		WantInitIntScaling = dfo_InitIntScaling();
 	} else {
-        if (!CanIntScaling) {
-            err = ReportParseFailure(
-                "-integer-scaling is only supported on SDL2 and Cocoa builds");
-        }
-    }
+		if (!CanIntScaling) {
+			err = ReportParseFailure(
+				"-integer-scaling is only supported on SDL2 and Cocoa builds");
+		}
+	}
 
 	return err;
 }

--- a/setup/SPCNFGAP.i
+++ b/setup/SPCNFGAP.i
@@ -76,7 +76,7 @@ LOCALPROC WriteAppSpecificCNFUDOSGoptions(void)
 	switch (cur_mdl) {
 		case gbk_mdl_Twig43:
 			WriteDestFileLn("#define kRomCheckSum1 0x27F4E04B");
-                        WriteDestFileLn("#define kRomCheckSum2 0x27DFC393");
+						WriteDestFileLn("#define kRomCheckSum2 0x27DFC393");
 			break;
 		case gbk_mdl_Twiggy:
 			WriteDestFileLn("#define kRomCheckSum1 0x2884371D");

--- a/setup/SPCNFGAP.i
+++ b/setup/SPCNFGAP.i
@@ -175,6 +175,8 @@ LOCALPROC WriteAppSpecificCNFUDOSGoptions(void)
 		WantVarFullScreen || WantInitFullScreen);
 	WriteCompCondBool("MayNotFullScreen",
 		WantVarFullScreen || ! WantInitFullScreen);
+	WriteCompCondBool("CanIntScaling", CanIntScaling);
+	WriteCompCondBool("WantInitIntScaling", WantInitIntScaling);
 
 	WriteCompCondBool("WantInitMagnify", WantInitMagnify);
 

--- a/src/CONTROLM.h
+++ b/src/CONTROLM.h
@@ -495,6 +495,9 @@ enum {
 #if VarFullScreen
 	kCntrlMsgFullScreen,
 #endif
+#if CanIntScaling
+    kCntrlMsgIntScaling,
+#endif
 #if WantEnblCtrlRst
 	kCntrlMsgConfirmResetStart,
 	kCntrlMsgHaveReset,
@@ -566,6 +569,10 @@ LOCALPROC SetSpeedValue(ui3b i)
 
 #if VarFullScreen
 FORWARDPROC ToggleWantFullScreen(void);
+#endif
+
+#if CanIntScaling
+FORWARDPROC ToggleWantIntegerScaling(void);
 #endif
 
 #if IncludeHostTextClipExchange
@@ -700,6 +707,12 @@ LOCALPROC DoControlModeKey(ui3r key)
 				case MKC_F:
 					ToggleWantFullScreen();
 					ControlMessage = kCntrlMsgFullScreen;
+					break;
+#endif
+#if CanIntScaling
+				case MKC_G:
+					ToggleWantIntegerScaling();
+					ControlMessage = kCntrlMsgIntScaling;
 					break;
 #endif
 #if IncludeHostTextClipExchange
@@ -923,7 +936,10 @@ LOCALPROC DrawCellsControlModeBody(void)
 			DrawCellsKeyCommand("M", kStrCmdMagnifyToggle);
 #endif
 #if VarFullScreen
-			DrawCellsKeyCommand("F", kStrCmdFullScrnToggle);
+            DrawCellsKeyCommand("F", kStrCmdFullScrnToggle);
+#endif
+#if CanIntScaling
+            DrawCellsKeyCommand("G", kStrCmdFullScrnIntScaleToggle);
 #endif
 #if WantEnblCtrlKtg
 			DrawCellsKeyCommand("K", kStrCmdCtrlKeyToggle);
@@ -977,6 +993,11 @@ LOCALPROC DrawCellsControlModeBody(void)
 #if VarFullScreen
 		case kCntrlMsgFullScreen:
 			DrawCellsOneLineStr(kStrNewFullScreen);
+			break;
+#endif
+#if CanIntScaling
+		case kCntrlMsgIntScaling:
+			DrawCellsOneLineStr(kStrNewIntScaling);
 			break;
 #endif
 #if IncludeHostTextClipExchange

--- a/src/CONTROLM.h
+++ b/src/CONTROLM.h
@@ -496,7 +496,7 @@ enum {
 	kCntrlMsgFullScreen,
 #endif
 #if CanIntScaling
-    kCntrlMsgIntScaling,
+	kCntrlMsgIntScaling,
 #endif
 #if WantEnblCtrlRst
 	kCntrlMsgConfirmResetStart,
@@ -936,10 +936,10 @@ LOCALPROC DrawCellsControlModeBody(void)
 			DrawCellsKeyCommand("M", kStrCmdMagnifyToggle);
 #endif
 #if VarFullScreen
-            DrawCellsKeyCommand("F", kStrCmdFullScrnToggle);
+			DrawCellsKeyCommand("F", kStrCmdFullScrnToggle);
 #endif
 #if CanIntScaling
-            DrawCellsKeyCommand("G", kStrCmdFullScrnIntScaleToggle);
+			DrawCellsKeyCommand("G", kStrCmdFullScrnIntScaleToggle);
 #endif
 #if WantEnblCtrlKtg
 			DrawCellsKeyCommand("K", kStrCmdCtrlKeyToggle);

--- a/src/INTLCHAR.h
+++ b/src/INTLCHAR.h
@@ -1794,13 +1794,13 @@ LOCALFUNC char * GetSubstitutionStr(char x)
 			break;
 #endif
 #if CanIntScaling
-        case 'i':
-            if (WantIntScaling) {
-                s = kStrOn;
-            } else {
-                s = kStrOff;
-            }
-            break;
+		case 'i':
+			if (WantIntScaling) {
+				s = kStrOn;
+			} else {
+				s = kStrOff;
+			}
+			break;
 #endif
 		case 'b':
 			if (RunInBackground) {

--- a/src/INTLCHAR.h
+++ b/src/INTLCHAR.h
@@ -1693,6 +1693,7 @@ LOCALVAR blnr RunInBackground = (WantInitRunInBackground != 0);
 
 #if VarFullScreen
 LOCALVAR blnr WantFullScreen = (WantInitFullScreen != 0);
+LOCALVAR blnr WantIntScaling = (WantInitIntScaling != 0);
 #endif
 
 #if EnableMagnify
@@ -1791,6 +1792,15 @@ LOCALFUNC char * GetSubstitutionStr(char x)
 				s = kStrOff;
 			}
 			break;
+#endif
+#if CanIntScaling
+        case 'i':
+            if (WantIntScaling) {
+                s = kStrOn;
+            } else {
+                s = kStrOff;
+            }
+            break;
 #endif
 		case 'b':
 			if (RunInBackground) {

--- a/src/OSGLUCCO.m
+++ b/src/OSGLUCCO.m
@@ -2033,85 +2033,85 @@ LOCALPROC MyDrawWithOpenGL(ui4r top, ui4r left, ui4r bottom, ui4r right)
 #endif
 
 		[MyNSOpnGLCntxt makeCurrentContext];
-        glClear(GL_COLOR_BUFFER_BIT);
+		glClear(GL_COLOR_BUFFER_BIT);
 
-        UpdateLuminanceCopy(top, left, bottom, right);
-        glRasterPos2i(left2, vMacScreenHeight * (UseMagnify ? MyWindowScale : 1) - top2);
+		UpdateLuminanceCopy(top, left, bottom, right);
+		glRasterPos2i(left2, vMacScreenHeight * (UseMagnify ? MyWindowScale : 1) - top2);
 
-        // Render everything to a texture. Then we can render the texture at whatever size we want, providing a true full screen.
-        glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
-        
+		// Render everything to a texture. Then we can render the texture at whatever size we want, providing a true full screen.
+		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+		
 #if 0 != vMacScreenDepth
-        if (UseColorMode) {
-            glDrawPixels(right - left,
-                bottom - top,
-                GL_RGBA,
-                GL_UNSIGNED_INT_8_8_8_8,
-                ScalingBuff + (left + top * vMacScreenWidth) * 4
-                );
-        } else
+		if (UseColorMode) {
+			glDrawPixels(right - left,
+				bottom - top,
+				GL_RGBA,
+				GL_UNSIGNED_INT_8_8_8_8,
+				ScalingBuff + (left + top * vMacScreenWidth) * 4
+				);
+		} else
 #endif
-        {
-            glDrawPixels(right - left,
-                bottom - top,
-                GL_LUMINANCE,
-                GL_UNSIGNED_BYTE,
-                ScalingBuff + (left + top * vMacScreenWidth)
-                );
-        }
-        
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
-        
-        NSSize bounds = MyNSview.frame.size;
-        NSRect renderRect;
-        double aspectRatio = (double)vMacScreenWidth / (double)vMacScreenHeight;
-        
-        if ((bounds.width / bounds.height) > aspectRatio) {
-            if (UseFullScreen && WantIntScaling) {
-                double pixelRatio = MyNSview.window.backingScaleFactor;
-                renderRect.size.height = floor(bounds.height / (vMacScreenHeight * pixelRatio)) * vMacScreenHeight * pixelRatio;
-            } else {
-                renderRect.size.height = bounds.height;
-            }
-            
-            renderRect.size.width = renderRect.size.height * aspectRatio;
-            renderRect.origin.x = (bounds.width - renderRect.size.width) / 2;
-            renderRect.origin.y = (bounds.height - renderRect.size.height) / 2;
-        } else {
-            if (UseFullScreen && WantIntScaling) {
-                double pixelRatio = MyNSview.window.backingScaleFactor;
-                renderRect.size.width = floor(bounds.width / (vMacScreenWidth * pixelRatio)) * vMacScreenWidth * pixelRatio;
-            } else {
-                renderRect.size.width = bounds.width;
-            }
-            
-            renderRect.size.width = bounds.width;
-            renderRect.size.height = bounds.width / aspectRatio; 
-            renderRect.origin.x = (bounds.width - renderRect.size.width) / 2;
-            renderRect.origin.y = (bounds.height - renderRect.size.height) / 2;
-        }
-        
-        glBindTexture(GL_TEXTURE_2D, texture);
-        
-        glEnable(GL_TEXTURE_2D);
-        glColor3f(1.0, 1.0, 1.0);
-        glBegin(GL_TRIANGLE_STRIP);
-        
-        glTexCoord2f(0.0, 0.0);
-        glVertex2f(renderRect.origin.x, renderRect.origin.y);
-        
-        glTexCoord2f(1.0, 0.0);
-        glVertex2f(renderRect.origin.x + renderRect.size.width, renderRect.origin.y);
-        
-        glTexCoord2f(0.0, 1.0);
-        glVertex2f(renderRect.origin.x, renderRect.origin.y + renderRect.size.height);
-        
-        glTexCoord2f(1.0, 1.0);
-        glVertex2f(renderRect.origin.x + renderRect.size.width, renderRect.origin.y + renderRect.size.height);
-        
-        glEnd();
-        glDisable(GL_TEXTURE_2D);
+		{
+			glDrawPixels(right - left,
+				bottom - top,
+				GL_LUMINANCE,
+				GL_UNSIGNED_BYTE,
+				ScalingBuff + (left + top * vMacScreenWidth)
+				);
+		}
+		
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		
+		NSSize bounds = MyNSview.frame.size;
+		NSRect renderRect;
+		double aspectRatio = (double)vMacScreenWidth / (double)vMacScreenHeight;
+		
+		if ((bounds.width / bounds.height) > aspectRatio) {
+			if (UseFullScreen && WantIntScaling) {
+				double pixelRatio = MyNSview.window.backingScaleFactor;
+				renderRect.size.height = floor(bounds.height / (vMacScreenHeight * pixelRatio)) * vMacScreenHeight * pixelRatio;
+			} else {
+				renderRect.size.height = bounds.height;
+			}
+			
+			renderRect.size.width = renderRect.size.height * aspectRatio;
+			renderRect.origin.x = (bounds.width - renderRect.size.width) / 2;
+			renderRect.origin.y = (bounds.height - renderRect.size.height) / 2;
+		} else {
+			if (UseFullScreen && WantIntScaling) {
+				double pixelRatio = MyNSview.window.backingScaleFactor;
+				renderRect.size.width = floor(bounds.width / (vMacScreenWidth * pixelRatio)) * vMacScreenWidth * pixelRatio;
+			} else {
+				renderRect.size.width = bounds.width;
+			}
+			
+			renderRect.size.width = bounds.width;
+			renderRect.size.height = bounds.width / aspectRatio; 
+			renderRect.origin.x = (bounds.width - renderRect.size.width) / 2;
+			renderRect.origin.y = (bounds.height - renderRect.size.height) / 2;
+		}
+		
+		glBindTexture(GL_TEXTURE_2D, texture);
+		
+		glEnable(GL_TEXTURE_2D);
+		glColor3f(1.0, 1.0, 1.0);
+		glBegin(GL_TRIANGLE_STRIP);
+		
+		glTexCoord2f(0.0, 0.0);
+		glVertex2f(renderRect.origin.x, renderRect.origin.y);
+		
+		glTexCoord2f(1.0, 0.0);
+		glVertex2f(renderRect.origin.x + renderRect.size.width, renderRect.origin.y);
+		
+		glTexCoord2f(0.0, 1.0);
+		glVertex2f(renderRect.origin.x, renderRect.origin.y + renderRect.size.height);
+		
+		glTexCoord2f(1.0, 1.0);
+		glVertex2f(renderRect.origin.x + renderRect.size.width, renderRect.origin.y + renderRect.size.height);
+		
+		glEnd();
+		glDisable(GL_TEXTURE_2D);
 
 #if 0 /* a very quick and dirty check of where drawing */
 		glDrawPixels(right - left,
@@ -3444,7 +3444,7 @@ LOCALPROC UngrabMachine(void)
 LOCALPROC MyAdjustGLforSize(int h, int v)
 {
 	[MyNSOpnGLCntxt makeCurrentContext];
-    int textureWidth = vMacScreenWidth, textureHeight = vMacScreenHeight;
+	int textureWidth = vMacScreenWidth, textureHeight = vMacScreenHeight;
 
 	glClearColor (0.0, 0.0, 0.0, 1.0);
 
@@ -3460,8 +3460,8 @@ LOCALPROC MyAdjustGLforSize(int h, int v)
 #if EnableMagnify
 	if (UseMagnify) {
 		glPixelZoom(MyWindowScale, - MyWindowScale);
-        textureWidth *= MyWindowScale;
-        textureHeight *= MyWindowScale;
+		textureWidth *= MyWindowScale;
+		textureHeight *= MyWindowScale;
 	} else
 #endif
 	{
@@ -3470,28 +3470,28 @@ LOCALPROC MyAdjustGLforSize(int h, int v)
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, vMacScreenWidth);
 
 	glClear(GL_COLOR_BUFFER_BIT);
-    
-    if (framebuffer == 0) {
-        glGenFramebuffers(1, &framebuffer);
-    }
-    
-    if (texture != 0) {
-        glDeleteTextures(1, &texture);
-    }
-    
-    glGenTextures(1, &texture);
-    glBindTexture(GL_TEXTURE_2D, texture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	
+	if (framebuffer == 0) {
+		glGenFramebuffers(1, &framebuffer);
+	}
+	
+	if (texture != 0) {
+		glDeleteTextures(1, &texture);
+	}
+	
+	glGenTextures(1, &texture);
+	glBindTexture(GL_TEXTURE_2D, texture);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 #if 0 != vMacScreenDepth
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, textureWidth, textureHeight, 0,  GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, NULL);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, textureWidth, textureHeight, 0,  GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, NULL);
 #else
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, textureWidth, textureHeight, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, NULL);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, textureWidth, textureHeight, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, NULL);
 #endif
-    
+	
 	[NSOpenGLContext clearCurrentContext];
 
 	ScreenChangedAll();
@@ -4364,7 +4364,7 @@ LOCALPROC ToggleWantFullScreen(void)
 
 LOCALPROC ToggleWantIntegerScaling(void)
 {
-    WantIntScaling = !WantIntScaling;
+	WantIntScaling = !WantIntScaling;
 }
 
 /* --- SavedTasks --- */
@@ -4790,17 +4790,17 @@ LOCALPROC ProcessEventLocation(NSEvent *event)
 LOCALPROC ProcessKeyEvent(blnr down, NSEvent *event)
 {
 	ui3r scancode = [event keyCode];
-    NSEventModifierFlags justModifiers = event.modifierFlags & (NSEventModifierFlagOption | NSEventModifierFlagCommand |
-                                                                NSEventModifierFlagControl | NSEventModifierFlagShift);
-    
-    if (((scancode == kVK_Return || scancode == kVK_ANSI_KeypadEnter) && justModifiers == NSEventModifierFlagOption) ||
-        (scancode == kVK_ANSI_F && justModifiers == NSEventModifierFlagCommand)) {
-        if (down) {
-            ToggleWantFullScreen();
-            NeedWholeScreenDraw = trueblnr;
-        }
-        return;
-    }
+	NSEventModifierFlags justModifiers = event.modifierFlags & (NSEventModifierFlagOption | NSEventModifierFlagCommand |
+																NSEventModifierFlagControl | NSEventModifierFlagShift);
+	
+	if (((scancode == kVK_Return || scancode == kVK_ANSI_KeypadEnter) && justModifiers == NSEventModifierFlagOption) ||
+		(scancode == kVK_ANSI_F && justModifiers == NSEventModifierFlagCommand)) {
+		if (down) {
+			ToggleWantFullScreen();
+			NeedWholeScreenDraw = trueblnr;
+		}
+		return;
+	}
 
 	ProcessEventModifiers(event);
 	Keyboard_UpdateKeyMap2(Keyboard_RemapMac(scancode), down);

--- a/src/OSGLUCCO.m
+++ b/src/OSGLUCCO.m
@@ -24,6 +24,7 @@
 	by Sam Lantinga (but little trace of that remains).
 */
 
+#include <Carbon/Carbon.h>
 #include "OSGCOMUI.h"
 #include "OSGCOMUD.h"
 
@@ -1464,6 +1465,8 @@ LOCALVAR ui3b MyBytesPerPixel;
 LOCALVAR NSOpenGLContext *MyNSOpnGLCntxt = nil;
 LOCALVAR short GLhOffset;
 LOCALVAR short GLvOffset;
+LOCALVAR GLuint texture = 0;
+LOCALVAR GLuint framebuffer = 0;
 	/* OpenGL coordinates of upper left point of drawing area */
 
 
@@ -2031,26 +2034,79 @@ LOCALPROC MyDrawWithOpenGL(ui4r top, ui4r left, ui4r bottom, ui4r right)
 
 		[MyNSOpnGLCntxt makeCurrentContext];
 
-		UpdateLuminanceCopy(top, left, bottom, right);
-		glRasterPos2i(GLhOffset + left2, GLvOffset - top2);
+        UpdateLuminanceCopy(top, left, bottom, right);
+        glRasterPos2i(left2, vMacScreenHeight * (UseMagnify ? MyWindowScale : 1) - top2);
+
+        // Render everything to a texture. Then we can render the texture at whatever size we want, providing a true full screen.
+        glBindTexture(GL_TEXTURE_2D, texture);
+        glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+        
 #if 0 != vMacScreenDepth
-		if (UseColorMode) {
-			glDrawPixels(right - left,
-				bottom - top,
-				GL_RGBA,
-				GL_UNSIGNED_INT_8_8_8_8,
-				ScalingBuff + (left + top * vMacScreenWidth) * 4
-				);
-		} else
+        if (UseColorMode) {
+            glDrawPixels(right - left,
+                bottom - top,
+                GL_RGBA,
+                GL_UNSIGNED_INT_8_8_8_8,
+                ScalingBuff + (left + top * vMacScreenWidth) * 4
+                );
+        } else
 #endif
-		{
-			glDrawPixels(right - left,
-				bottom - top,
-				GL_LUMINANCE,
-				GL_UNSIGNED_BYTE,
-				ScalingBuff + (left + top * vMacScreenWidth)
-				);
-		}
+        {
+            glDrawPixels(right - left,
+                bottom - top,
+                GL_LUMINANCE,
+                GL_UNSIGNED_BYTE,
+                ScalingBuff + (left + top * vMacScreenWidth)
+                );
+        }
+            
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        
+        NSSize bounds = MyNSview.frame.size;
+        NSRect renderRect;
+        double aspectRatio = (double)vMacScreenWidth / (double)vMacScreenHeight;
+        
+        if ((bounds.width / bounds.height) > aspectRatio) {
+            double integralScalingHeight = floor(bounds.height / vMacScreenHeight) * vMacScreenHeight;
+            double borderPercentage = (bounds.height - integralScalingHeight) / bounds.height;
+
+            if (borderPercentage < 0.06) {
+                // Use integral scaling if it doesn't create too much of a border
+                // This makes rendering full screen in 720p or 1080p look a lot better!
+                renderRect.size.height = integralScalingHeight;
+            } else {
+                renderRect.size.height = bounds.height; 
+            }
+            
+            renderRect.size.width = renderRect.size.height * aspectRatio;
+            renderRect.origin.x = (bounds.width - renderRect.size.width) / 2;
+            renderRect.origin.y = (bounds.height - renderRect.size.height) / 2;
+        } else {
+            renderRect.size.width = bounds.width;
+            renderRect.size.height = bounds.width / aspectRatio; 
+            renderRect.origin.x = (bounds.width - renderRect.size.width) / 2;
+            renderRect.origin.y = (bounds.height - renderRect.size.height) / 2;
+        }
+        
+        glEnable(GL_TEXTURE_2D);
+        glColor3f(1.0, 1.0, 1.0);
+        glBegin(GL_TRIANGLE_STRIP);
+        
+        glTexCoord2f(0.0, 0.0);
+        glVertex2f(renderRect.origin.x, renderRect.origin.y);
+        
+        glTexCoord2f(1.0, 0.0);
+        glVertex2f(renderRect.origin.x + renderRect.size.width, renderRect.origin.y);
+        
+        glTexCoord2f(0.0, 1.0);
+        glVertex2f(renderRect.origin.x, renderRect.origin.y + renderRect.size.height);
+        
+        glTexCoord2f(1.0, 1.0);
+        glVertex2f(renderRect.origin.x + renderRect.size.width, renderRect.origin.y + renderRect.size.height);
+        
+        glEnd();
+        glDisable(GL_TEXTURE_2D);
 
 #if 0 /* a very quick and dirty check of where drawing */
 		glDrawPixels(right - left,
@@ -3383,6 +3439,7 @@ LOCALPROC UngrabMachine(void)
 LOCALPROC MyAdjustGLforSize(int h, int v)
 {
 	[MyNSOpnGLCntxt makeCurrentContext];
+    int textureWidth = vMacScreenWidth, textureHeight = vMacScreenHeight;
 
 	glClearColor (0.0, 0.0, 0.0, 1.0);
 
@@ -3398,6 +3455,8 @@ LOCALPROC MyAdjustGLforSize(int h, int v)
 #if EnableMagnify
 	if (UseMagnify) {
 		glPixelZoom(MyWindowScale, - MyWindowScale);
+        textureWidth *= MyWindowScale;
+        textureHeight *= MyWindowScale;
 	} else
 #endif
 	{
@@ -3406,7 +3465,28 @@ LOCALPROC MyAdjustGLforSize(int h, int v)
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, vMacScreenWidth);
 
 	glClear(GL_COLOR_BUFFER_BIT);
-
+    
+    if (framebuffer == 0) {
+        glGenFramebuffers(1, &framebuffer);
+    }
+    
+    if (texture != 0) {
+        glDeleteTextures(1, &texture);
+    }
+    
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+#if 0 != vMacScreenDepth
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, textureWidth, textureHeight, 0,  GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, NULL);
+#else
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, textureWidth, textureHeight, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, NULL);
+#endif
+    
 	[NSOpenGLContext clearCurrentContext];
 
 	ScreenChangedAll();
@@ -3783,7 +3863,6 @@ LOCALFUNC blnr CreateMainWindow(void)
 #endif
 	unsigned int style;
 	NSRect MainScrnBounds;
-	NSRect AllScrnBounds;
 	NSRect NewWinRect;
 	NSPoint botleftPos;
 	int NewWindowHeight = vMacScreenHeight;
@@ -3804,17 +3883,6 @@ LOCALFUNC blnr CreateMainWindow(void)
 
 	MainScrnBounds = [[NSScreen mainScreen] frame];
 	SavedScrnBounds = MainScrnBounds;
-	{
-		int i;
-		NSArray *screens = [NSScreen screens];
-		int n = [screens count];
-
-		AllScrnBounds = MainScrnBounds;
-		for (i = 0; i < n; ++i) {
-			AllScrnBounds = NSUnionRect(AllScrnBounds,
-				[[screens objectAtIndex:i] frame]);
-		}
-	}
 
 #if EnableMagnify
 	if (UseMagnify) {
@@ -3870,15 +3938,15 @@ LOCALFUNC blnr CreateMainWindow(void)
 #endif
 #if MayFullScreen
 	{
-		NewWinRect = AllScrnBounds;
+		NewWinRect = MainScrnBounds;
 
-		GLhOffset = botleftPos.x - AllScrnBounds.origin.x;
-		GLvOffset = (botleftPos.y - AllScrnBounds.origin.y)
+		GLhOffset = botleftPos.x - MainScrnBounds.origin.x;
+		GLvOffset = (botleftPos.y - MainScrnBounds.origin.y)
 			+ ((NewWindowHeight < MainScrnBounds.size.height)
 				? NewWindowHeight : MainScrnBounds.size.height);
 
 		hOffset = GLhOffset;
-		vOffset = AllScrnBounds.size.height - GLvOffset;
+		vOffset = MainScrnBounds.size.height - GLvOffset;
 
 		style = MyNSWindowStyleMaskBorderless;
 	}
@@ -4712,6 +4780,17 @@ LOCALPROC ProcessEventLocation(NSEvent *event)
 LOCALPROC ProcessKeyEvent(blnr down, NSEvent *event)
 {
 	ui3r scancode = [event keyCode];
+    NSEventModifierFlags justModifiers = event.modifierFlags & (NSEventModifierFlagOption | NSEventModifierFlagCommand |
+                                                                NSEventModifierFlagControl | NSEventModifierFlagShift);
+    
+    if (((scancode == kVK_Return || scancode == kVK_ANSI_KeypadEnter) && justModifiers == NSEventModifierFlagOption) ||
+        (scancode == kVK_ANSI_F && justModifiers == NSEventModifierFlagCommand)) {
+        if (down) {
+            ToggleWantFullScreen();
+            NeedWholeScreenDraw = trueblnr;
+        }
+        return;
+    }
 
 	ProcessEventModifiers(event);
 	Keyboard_UpdateKeyMap2(Keyboard_RemapMac(scancode), down);

--- a/src/OSGLUSDL.c
+++ b/src/OSGLUSDL.c
@@ -1772,6 +1772,17 @@ LOCALPROC DoKeyCode(SDL_keysym *r, blnr down)
 #elif 2 == SDL_MAJOR_VERSION
 LOCALPROC DoKeyCode(SDL_Keysym *r, blnr down)
 {
+	int justModifiers = r->mod & (KMOD_CTRL | KMOD_SHIFT | KMOD_ALT | KMOD_GUI);
+	if (r->scancode == SDL_SCANCODE_RETURN &&
+		(justModifiers == KMOD_LALT || justModifiers == KMOD_RALT)) {
+		// Alt+Enter
+		if (down) {
+			ToggleWantFullScreen();
+			NeedWholeScreenDraw = trueblnr;
+		}
+		return;
+	}
+
 	ui3r v = SDLScan2MacKeyCode(r->scancode);
 	if (MKC_None != v) {
 		Keyboard_UpdateKeyMap2(v, down);

--- a/src/OSGLUSDL.c
+++ b/src/OSGLUSDL.c
@@ -1167,17 +1167,51 @@ LOCALPROC HaveChangedScreenBuff(ui4r top, ui4r left,
 #elif 2 == SDL_MAJOR_VERSION
 	SDL_UnlockTexture(my_texture);
 
-	src_rect.x = left2;
-	src_rect.y = top2;
-	src_rect.w = right2 - left2;
-	src_rect.h = bottom2 - top2;
+	// Scale the texture to fill the entire window
+	// Allows for proper full screen mode
 
-	dst_rect.x = XDest;
-	dst_rect.y = YDest;
-	dst_rect.w = DestWidth;
-	dst_rect.h = DestHeight;
+	src_rect.x = 0;
+	src_rect.y = 0;
 
-	/* SDL_RenderClear(my_renderer); */
+	if (UseMagnify) {
+		src_rect.w = vMacScreenWidth * MyWindowScale;
+		src_rect.h = vMacScreenHeight * MyWindowScale;
+	}
+	else {
+		src_rect.w = vMacScreenWidth;
+		src_rect.h = vMacScreenHeight;
+	}
+
+	int rendererWidth, rendererHeight;
+	SDL_GetRendererOutputSize(my_renderer, &rendererWidth, &rendererHeight);
+
+	SDL_Rect renderRect;
+	double aspectRatio = (double)vMacScreenWidth / (double)vMacScreenHeight;
+
+	if (((double)rendererWidth / (double)rendererHeight) > aspectRatio) {
+		if (UseFullScreen && WantIntScaling) {
+			dst_rect.h = floor(rendererHeight / vMacScreenHeight) * vMacScreenHeight;
+		} else {
+			dst_rect.h = rendererHeight;
+		}
+
+		dst_rect.w = lround(dst_rect.h * aspectRatio);
+	}
+	else {
+		if (UseFullScreen && WantIntScaling) {
+			dst_rect.w = floor(rendererWidth / vMacScreenWidth) * vMacScreenWidth;
+		}
+		else {
+			dst_rect.w = rendererWidth;
+		}
+
+		dst_rect.h = lround(dst_rect.w / aspectRatio);
+	}
+
+	dst_rect.x = (rendererWidth - dst_rect.w) / 2;
+	dst_rect.y = (rendererHeight - dst_rect.h) / 2;
+
+	SDL_SetTextureScaleMode(my_texture, SDL_ScaleModeLinear);
 	SDL_RenderCopy(my_renderer, my_texture, &src_rect, &dst_rect);
 	SDL_RenderPresent(my_renderer);
 
@@ -3995,14 +4029,24 @@ LOCALFUNC blnr CreateMainWindow(void)
 #endif
 #if MayFullScreen
 	{
+		int WinIndx = UseMagnify ? kMagStateMagnifgy : kMagStateNormal;
 		/*
 			We don't want physical screen mode to be changed in modern
 			displays, so we pass this _DESKTOP flag.
 		*/
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
-		NewWindowX = SDL_WINDOWPOS_UNDEFINED;
-		NewWindowY = SDL_WINDOWPOS_UNDEFINED;
+		if (!HavePositionWins[WinIndx]) {
+			NewWindowX = SDL_WINDOWPOS_UNDEFINED;
+			NewWindowY = SDL_WINDOWPOS_UNDEFINED;
+		}
+		else {
+			/* Go full screen on whichever display the window previous occupied! */
+			SDL_Rect windowRect = { WinPositionsX[WinIndx], WinPositionsY[WinIndx], NewWindowWidth, NewWindowHeight };
+			int targetDisplay = SDL_GetRectDisplayIndex(&windowRect);
+			NewWindowX = SDL_WINDOWPOS_CENTERED_DISPLAY(targetDisplay);
+			NewWindowY = SDL_WINDOWPOS_CENTERED_DISPLAY(targetDisplay);
+		}
 	}
 #endif
 #if VarFullScreen
@@ -4048,7 +4092,7 @@ LOCALFUNC blnr CreateMainWindow(void)
 	} else
 	if (NULL == (my_renderer = SDL_CreateRenderer(
 		my_main_wind, -1,
-		0 /* SDL_RENDERER_ACCELERATED|SDL_RENDERER_PRESENTVSYNC */
+		SDL_RENDERER_PRESENTVSYNC /* SDL_RENDERER_ACCELERATED|SDL_RENDERER_PRESENTVSYNC */
 			/*
 				SDL_RENDERER_ACCELERATED not needed
 				"no flags gives priority to available
@@ -4442,6 +4486,12 @@ LOCALPROC ToggleWantFullScreen(void)
 #endif
 }
 #endif
+
+LOCALPROC ToggleWantIntegerScaling(void)
+{
+	WantIntScaling = !WantIntScaling;
+	SDL_RenderClear(my_renderer);
+}
 
 /* --- SavedTasks --- */
 

--- a/src/STRCNCAT.h
+++ b/src/STRCNCAT.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Control de velocitat;ll (^s)"
 #define kStrCmdMagnifyToggle "Magnificaci;eo (^g)"
 #define kStrCmdFullScrnToggle "Pantalla completa (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Escala enters a pantalla completa (^i)"
 #define kStrCmdCtrlKeyToggle "Toggle emulaci;eo tecla ;]^m;} (^k)"
 #define kStrCmdReset "Restablir"
 #define kStrCmdInterrupt "Interrompre"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "Magnificaci;eo est;`a ^g."
 
 #define kStrNewFullScreen "Pantalla completa est;`a ^f."
+#define kStrNewIntScaling "L'escala d'enters ;ees ^i."
 
 #define kStrNewCntrlKey "Emulat tecla ;]^m;} ^k."
 

--- a/src/STRCNCZE.h
+++ b/src/STRCNCZE.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Ovl;ead;ean;ei rychlosti;ll (^s)"
 #define kStrCmdMagnifyToggle "P;vribl;ei;vzen;ei (^g)"
 #define kStrCmdFullScrnToggle "Cel;ea obrazovka (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Cel;`a obrazovka celo;vc;eiseln;ee ;vsk;`alov;`an;ei (^i)"
 #define kStrCmdCtrlKeyToggle "P;vrep;ein;ean;ei emulovan;eeho ;]^m;} (^k)"
 #define kStrCmdReset "Reset"
 #define kStrCmdInterrupt "Vyru;vsit"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "P;vribl;ei;vzen;ei: ^g."
 
 #define kStrNewFullScreen "Na celou obrazovku: ^f."
+#define kStrNewIntScaling "M;ve;vr;eitko cel;eeho ;vc;eisla je ^i."
 
 #define kStrNewCntrlKey "Emulovan;ey ;]^m;}: ^k."
 

--- a/src/STRCNDUT.h
+++ b/src/STRCNDUT.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Snelheidscontrole;ll (^s)"
 #define kStrCmdMagnifyToggle "Schermvergroting (^g)"
 #define kStrCmdFullScrnToggle "Gebruik het volledig scherm (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Volledig scherm integer schaling (^i)"
 #define kStrCmdCtrlKeyToggle "Ge;uemuleerde ;]^m;} toets (^k)"
 #define kStrCmdReset "Herstart"
 #define kStrCmdInterrupt "Onderbreek"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "Schermvergroting is ^g."
 
 #define kStrNewFullScreen "Volledig scherm gebruiken is ^f."
+#define kStrNewIntScaling "Integer schaling is ^i."
 
 #define kStrNewCntrlKey "Ge;uemuleerde ;]^m;} toets ^k."
 

--- a/src/STRCNENG.h
+++ b/src/STRCNENG.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Speed control;ll (^s)"
 #define kStrCmdMagnifyToggle "Magnify toggle (^g)"
 #define kStrCmdFullScrnToggle "Full screen toggle (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Full screen integer scaling (^i)"
 #define kStrCmdCtrlKeyToggle "emulated ;]^m;} Key toggle (^k)"
 #define kStrCmdReset "Reset"
 #define kStrCmdInterrupt "Interrupt"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "Magnify is ^g."
 
 #define kStrNewFullScreen "Full Screen is ^f."
+#define kStrNewIntScaling "Integer Scaling is ^i."
 
 #define kStrNewCntrlKey "Emulated ;]^m;} key ^k."
 

--- a/src/STRCNFRE.h
+++ b/src/STRCNFRE.h
@@ -92,6 +92,7 @@
 #define kStrCmdSpeedControl "R;eeglage de la vitesse;ll (^s)"
 #define kStrCmdMagnifyToggle "Agrandissement (^g)"
 #define kStrCmdFullScrnToggle "Plein ;eecran (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Mise ;`a l';eechelle des entiers en plein ;eecran (^i)"
 #define kStrCmdCtrlKeyToggle "Touche ^m virtuelle (^k)"
 #define kStrCmdReset "R;eeinitialisation"
 #define kStrCmdInterrupt "Interruption"
@@ -115,6 +116,7 @@
 #define kStrNewMagnify "Agrandissement ^g."
 
 #define kStrNewFullScreen "Mode plein ;eecran ^f."
+#define kStrNewIntScaling "La mise ;`a l';eechelle des entiers est ^i."
 
 #define kStrNewCntrlKey "Touche ^m virtuelle ^k."
 

--- a/src/STRCNGER.h
+++ b/src/STRCNGER.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Geschwindigkeitskontrolle;ll (^s)"
 #define kStrCmdMagnifyToggle "Vergr;uosserung (^g)"
 #define kStrCmdFullScrnToggle "Vollbild (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Ganzzahlskalierung im Vollbildmodus (^i)"
 #define kStrCmdCtrlKeyToggle "Emulierte ;]^m;}-Taste (^k)"
 #define kStrCmdReset "Neustarten (Reset durchf;uuhren)"
 #define kStrCmdInterrupt "Interrupt"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "Vergr;uo;serung ist ^g"
 
 #define kStrNewFullScreen "Vollbildmodus ist ^f"
+#define kStrNewIntScaling "Ganzzahlskalierung ist ^i."
 
 #define kStrNewCntrlKey "Emulierte ;]^m;}-Taste ^k"
 

--- a/src/STRCNITA.h
+++ b/src/STRCNITA.h
@@ -94,6 +94,7 @@
 #define kStrCmdSpeedControl "Controllo velocit;`a;ll (^s)"
 #define kStrCmdMagnifyToggle "Ingrandimento (^g)"
 #define kStrCmdFullScrnToggle "Schermo intero (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Ridimensionamento intero a schermo intero (^i)"
 #define kStrCmdCtrlKeyToggle "Tasto ;]^m;} emulato (^k)"
 #define kStrCmdReset "Reset"
 #define kStrCmdInterrupt "Interrupt"
@@ -117,6 +118,7 @@
 #define kStrNewMagnify "L;laingrandimento ;`e ^g"
 
 #define kStrNewFullScreen "Lo schermo intero ;`e ^f"
+#define kStrNewIntScaling "Il ridimensionamento intero ;`e ^i."
 
 #define kStrNewCntrlKey "Il tasto ;]^m;} emulato ;`e ^k"
 

--- a/src/STRCNPOL.h
+++ b/src/STRCNPOL.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Kontrola szybko;esci;ll (^s)"
 #define kStrCmdMagnifyToggle "Skalowanie (^g)"
 #define kStrCmdFullScrnToggle "Pe;dlny ekran (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Skalowanie ca;dlkowite na pe;dlnym ekranie (^i)"
 #define kStrCmdCtrlKeyToggle "Emulowany klawisz ^m (^k)"
 #define kStrCmdReset "Reset"
 #define kStrCmdInterrupt "Przerwanie"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "Powi;dekszenie jest ^g."
 
 #define kStrNewFullScreen "Pe;dlny ekran jest ^f."
+#define kStrNewIntScaling "Skalowanie ca;dlkowite to ^i."
 
 #define kStrNewCntrlKey "Emulowany klawiszem ^m jest ^k."
 

--- a/src/STRCNPTB.h
+++ b/src/STRCNPTB.h
@@ -117,6 +117,7 @@
 #define kStrCmdMagnifyToggle "Zoom (^g)"
 
 #define kStrCmdFullScrnToggle "Tela Cheia (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Escala de inteiros em tela cheia (^i)"
 
 #define kStrCmdCtrlKeyToggle "Alternar Tecla ;]^m;} emulada (^k)"
 
@@ -152,6 +153,7 @@
 #define kStrNewMagnify "Zoom est;ea ^g."
 
 #define kStrNewFullScreen "Tela Cheia est;ea ^f."
+#define kStrNewIntScaling "A escala de inteiros ;ee ^i."
 
 #define kStrNewCntrlKey "Emula;c;nao da tecla ;]^m;} ^k."
 

--- a/src/STRCNSPA.h
+++ b/src/STRCNSPA.h
@@ -91,6 +91,7 @@
 #define kStrCmdSpeedControl "Control de velocidad;ll (^s)"
 #define kStrCmdMagnifyToggle "Magnificaci;eon (^g)"
 #define kStrCmdFullScrnToggle "Pantalla completa (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Escala enteros en pantalla completa (^i)"
 #define kStrCmdCtrlKeyToggle "Toggle emulaci;eon tecla ;]^m;} (^k)"
 #define kStrCmdReset "Reset"
 #define kStrCmdInterrupt "Interrumpir"
@@ -114,6 +115,7 @@
 #define kStrNewMagnify "Magnificaci;eon est;ea ^g."
 
 #define kStrNewFullScreen "Pantalla completa est;ea ^f."
+#define kStrNewIntScaling "Escala de n;eumeros enteros es ^i."
 
 #define kStrNewCntrlKey "Emulado tecla ;]^m;} ^k."
 

--- a/src/STRCNSRL.h
+++ b/src/STRCNSRL.h
@@ -107,6 +107,7 @@
 #define kStrCmdSpeedControl "Kontrola brzine;ll (^s)"
 #define kStrCmdMagnifyToggle "Prekida;vc lupe (^g)"
 #define kStrCmdFullScrnToggle "Prekida;vc re;vzima celog ekrana (^f)"
+#define kStrCmdFullScrnIntScaleToggle "Tselobrojno skaliranje preko tselog ekrana (^i)"
 #define kStrCmdCtrlKeyToggle "Prekida;vc emulisanog tastera ;]^m;} (^k)"
 #define kStrCmdReset "Resetuj"
 #define kStrCmdInterrupt "Prekid"
@@ -130,6 +131,7 @@
 #define kStrNewMagnify "Pribli;vzi je ^g."
 
 #define kStrNewFullScreen "Ceo ekran je ^f."
+#define kStrNewIntScaling "Tselobrojno skaliranje je ^i."
 
 #define kStrNewCntrlKey "Emulisani taster ;]^m;} je ^k."
 


### PR DESCRIPTION
This makes it so that toggling full screen will actually fill the screen completely, or optionally fill the screen as much as possible while still scaling the display by an integral amount. The latter setting can be accessed in the control menu, and there is a new command line argument `-integer-scaling` for the configuration tool that specifies whether integer scaling is enabled or disabled by default. Toggling full screen will also fill the screen that Mini vMac's window currently occupies, rather than just the primary display.